### PR TITLE
Added Button For Loading More Editions

### DIFF
--- a/pages/api/works/editions.js
+++ b/pages/api/works/editions.js
@@ -4,7 +4,7 @@ const cheerio = require("cheerio");
 
 const EditionScraper = async (req, res) => {
   if (req.method === "POST") {
-    const scrapeURL = req.body.queryURL.split("&")[0];
+    const scrapeURL = req.body.queryURL;
 
     try {
       const response = await fetch(`${scrapeURL}`, {


### PR DESCRIPTION
Fixes #31 . 

Added a button to load the next 10 editions in a work's editions page, adding to the already present ones. 
Count resets when adding a filter for format, and returns when switching back to default (all formats) without sending more requests.
If the user loaded all the available editions the (Goodreads returns an empty response) the button is disabled. 

Examples:
![image](https://github.com/user-attachments/assets/87d81e83-9708-4c53-ba6e-43a09c9e418a)
![image](https://github.com/user-attachments/assets/9431d09c-e2c7-47b8-833c-1e24954e2afd)
![image](https://github.com/user-attachments/assets/fcbeddd4-0a71-473c-8fba-6b58f3bf724d)
